### PR TITLE
fix bug that unsets empty flags on client

### DIFF
--- a/server/src/TPlayer.cpp
+++ b/server/src/TPlayer.cpp
@@ -2056,7 +2056,7 @@ void TPlayer::setFlag(const CString& pFlagName, const CString& pFlagValue, bool 
 	if (sendToPlayer)
 	{
 		if (pFlagValue.isEmpty())
-			sendPacket(CString() >> (char)PLO_FLAGDEL << pFlagName);
+			sendPacket(CString() >> (char)PLO_FLAGSET << pFlagName);
 		else
 			sendPacket(CString() >> (char)PLO_FLAGSET << pFlagName << "=" << pFlagValue);
 	}


### PR DESCRIPTION
This fixes a problem where flags without values get removed from a player when the RC updates their attributes.